### PR TITLE
Fixed problem when used with webpack-dev-server

### DIFF
--- a/src/generateFonts.js
+++ b/src/generateFonts.js
@@ -122,7 +122,7 @@ var generateFonts = function(options) {
 	}
 
 	// Create all needed generate and write tasks.
-	for (var i in options.types) {
+	for (var i = 0; i < options.types.length; i++) {
 		var type = options.types[i]
 		makeGenTask(type)
 	}


### PR DESCRIPTION
Avoided for/in to enumerate an array since webpack-dev-server is using a (quite questionable) polyfill to add an includes function to Array.prototype without making it non-enumerable, and it's causing problems in webfonts-loader.